### PR TITLE
Fix Maven Surefire plugin configuration in account-analytics-service

### DIFF
--- a/account-analytics-service/pom.xml
+++ b/account-analytics-service/pom.xml
@@ -152,6 +152,32 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Exclude integration tests from unit test phase -->
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                    </excludes>
+                    <!-- Don't fail if no unit tests are found -->
+                    <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!-- Include integration tests -->
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Configure Surefire plugin to exclude integration tests (*IT.java) from unit test phase
- Add failIfNoSpecifiedTests=false to prevent errors when no unit tests exist
- Add Maven Failsafe plugin to properly run integration tests during verify phase
- Align configuration with main spring-boot-microservices-demo project structure