### PR TITLE
Fix GitHub Actions workflow secret usage in conditions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -209,7 +209,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
       
     - name: Log in to Docker Hub
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.DOCKER_HUB_USERNAME != '' && secrets.DOCKER_HUB_ACCESS_TOKEN != ''
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -221,7 +221,7 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         images: |
-          ${{ secrets.DOCKER_HUB_USERNAME != '' && secrets.DOCKER_HUB_USERNAME || 'local' }}/portfolio-banking-service
+          ${{ secrets.DOCKER_HUB_USERNAME || 'local' }}/portfolio-banking-service
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -234,7 +234,7 @@ jobs:
         context: ./spring-boot-microservices-demo
         file: ./spring-boot-microservices-demo/Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.DOCKER_HUB_USERNAME != '' && secrets.DOCKER_HUB_ACCESS_TOKEN != '' }}
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
@@ -255,7 +255,7 @@ jobs:
 
 
     - name: Upload Docker image info
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.DOCKER_HUB_USERNAME != '' && secrets.DOCKER_HUB_ACCESS_TOKEN != ''
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v4
       with:
         name: docker-image-info


### PR DESCRIPTION
- Remove secrets from if conditions (not allowed in GitHub Actions)
- Docker Hub login will still work with continue-on-error: true
- Docker push will attempt but fail gracefully if credentials missing
- Maintain existing error handling in Docker push status step