### PR TITLE
Remove code quality analysis from GitHub workflows

### DIFF
--- a/.github/workflows/account-analytics-service.yml
+++ b/.github/workflows/account-analytics-service.yml
@@ -146,63 +146,6 @@ jobs:
           find target/failsafe-reports -name "*.xml" -exec basename {} \; | head -5 >> $GITHUB_STEP_SUMMARY
         fi
 
-  code-quality:
-    name: Code Quality Analysis
-    runs-on: ubuntu-latest
-    needs: build
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-      
-    - name: Set up JDK ${{ env.JAVA_VERSION }}
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'temurin'
-        cache: maven
-        
-    - name: Cache Maven dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-analytics-${{ hashFiles('account-analytics-service/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-m2-analytics-
-          ${{ runner.os }}-m2-
-        
-    - name: Download build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: analytics-build-artifacts
-        path: account-analytics-service/target/classes/
-        
-    - name: Run SpotBugs Analysis
-      working-directory: ./account-analytics-service
-      run: |
-        mvn compile spotbugs:check -B --no-transfer-progress || echo "SpotBugs analysis completed"
-      continue-on-error: true
-      
-    - name: Run Dependency Check
-      working-directory: ./account-analytics-service
-      run: |
-        mvn org.owasp:dependency-check-maven:check \
-          -DfailBuildOnCVSS=8 \
-          -DskipTests=true \
-          -B --no-transfer-progress
-      continue-on-error: true
-      
-    - name: Upload Code Quality Reports
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: analytics-quality-reports
-        path: |
-          account-analytics-service/target/spotbugsXml.xml
-          account-analytics-service/target/dependency-check-report.html
-        retention-days: 7
 
   package:
     name: Package Analytics Service
@@ -344,7 +287,7 @@ jobs:
   notify:
     name: Notify Analytics Results
     runs-on: ubuntu-latest
-    needs: [build, test, code-quality, package, docker]
+    needs: [build, test, package, docker]
     if: always()
     
     steps:
@@ -356,7 +299,6 @@ jobs:
         echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
         echo "| Build | ${{ needs.build.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Tests | ${{ needs.test.result }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Code Quality | ${{ needs.code-quality.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Package | ${{ needs.package.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Docker | ${{ needs.docker.result }} |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -264,50 +264,11 @@ jobs:
         retention-days: 30
       continue-on-error: true
 
-  security-scan:
-    name: Banking Security Scan
-    runs-on: ubuntu-latest
-    needs: [changes, build]
-    if: needs.changes.outputs.banking-service == 'true'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Set up JDK ${{ env.JAVA_VERSION }}
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'temurin'
-        cache: maven
-        
-    - name: Cache Maven dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-        
-    - name: Run OWASP Dependency Check
-      working-directory: ./spring-boot-microservices-demo
-      run: |
-        mvn org.owasp:dependency-check-maven:check \
-          -DfailBuildOnCVSS=7 \
-          -DskipTests=true
-      continue-on-error: true
-      
-    - name: Upload Security Reports
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: security-reports
-        path: spring-boot-microservices-demo/target/dependency-check-report.html
-        retention-days: 7
 
   notify:
     name: Notify Pipeline Results
     runs-on: ubuntu-latest
-    needs: [changes, build, test, package, docker, security-scan]
+    needs: [changes, build, test, package, docker]
     if: always() && (needs.changes.outputs.banking-service == 'true' || needs.changes.outputs.analytics-service == 'true')
     
     steps:
@@ -327,7 +288,6 @@ jobs:
           echo "| Tests | ${{ needs.test.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Package | ${{ needs.package.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Docker | ${{ needs.docker.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Security | ${{ needs.security-scan.result }} |" >> $GITHUB_STEP_SUMMARY
         fi
 
     - name: Notify Success
@@ -340,7 +300,6 @@ jobs:
         echo "Tests: ${{ needs.test.result }}"
         echo "Package: ${{ needs.package.result }}"
         echo "Docker: ${{ needs.docker.result || 'skipped (no Docker Hub credentials)' }}"
-        echo "Security: ${{ needs.security-scan.result }}"
         
     - name: Notify Failure
       if: needs.build.result == 'failure' || needs.test.result == 'failure'
@@ -350,5 +309,4 @@ jobs:
         echo "Tests: ${{ needs.test.result }}"
         echo "Package: ${{ needs.package.result }}"
         echo "Docker: ${{ needs.docker.result || 'skipped (no Docker Hub credentials)' }}"
-        echo "Security: ${{ needs.security-scan.result }}"
         exit 1


### PR DESCRIPTION
- Remove code-quality job from account-analytics-service.yml (SpotBugs and OWASP dependency check)
- Remove security-scan job from ci-cd.yml (OWASP dependency check)
- Update job dependencies to remove references to removed jobs
- Remove code quality status from pipeline summary outputs

This speeds up the CI/CD pipelines by removing time-consuming analysis steps.